### PR TITLE
ERRO 502: Bad Gateway 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,11 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation group: 'com.zendesk', name: 'chat', version: '3.1.0'
-    implementation group: 'com.zendesk', name: 'messaging', version: '5.1.0'
-    implementation group: 'com.zendesk', name: 'chat-providers', version: '3.1.0'
+    //implementation group: 'com.zendesk', name: 'chat', version: '3.1.0'
+    //implementation group: 'com.zendesk', name: 'messaging', version: '5.1.0'
+    //implementation group: 'com.zendesk', name: 'chat-providers', version: '3.1.0'
+    implementation "com.zendesk:chat:3.3.2"
+    implementation "com.zendesk:messaging:5.2.2"
+    implementation "com.zendesk:chat-providers:3.3.2"
+
 }


### PR DESCRIPTION
[en-US]
In the app that I develop for a company in Brazil, error 502 of request to the server occurred.

Could not HEAD 'https://google.bintray.com/exoplayer/com/zendesk/chat/3.1.0/chat-3.1.0.pom'. Received status code 502 from server: Bad Gateway

The solution found was to update the resource versions used in build.gradle.

[pt-BR]
No app que desenvolvo para uma empresa no brazil, aconteceu o erro 502 de requisiçao ao servidor.

Could not HEAD 'https://google.bintray.com/exoplayer/com/zendesk/chat/3.1.0/chat-3.1.0.pom'. Received status code 502 from server: Bad Gateway 

A soluçao encontrada foi atualizar as versões do recursos utilizados no build.gradle.